### PR TITLE
fix mobile menu

### DIFF
--- a/src/assets/script/nav-links.js
+++ b/src/assets/script/nav-links.js
@@ -13,10 +13,6 @@ class NavLinks extends HTMLElement {
 				burger.checked = false;
 			}
 		});
-
-		burger.addEventListener('change', () => {
-			document.body.classList.toggle('Ov-h', burger.checked);
-		});
 	}
 }
 


### PR DESCRIPTION
При переходе по ссылке в мобильном меню, страница нге скролится. Мой косяк. Я блокировал скролл, когда меню открывается и разблокировал, когда меню закрыто. Все убрал.